### PR TITLE
Fix permission problem with soapy-sdr

### DIFF
--- a/debian/dump978-fa.postinst
+++ b/debian/dump978-fa.postinst
@@ -31,6 +31,8 @@ case "$1" in
 
         # plugdev required for USB access
         adduser "$RUNAS" plugdev
+        # audio required for soapy-sdr in some cases
+        adduser "$RUNAS" audio
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
Depending on installation of certain modules Soapy-SDR opens a pcm
device which requires permissions of the audio group.

You probably don't need this PR but it was already done, feel free to just toss it into the bin.