### PR TITLE
Fix maybe-unitialized compilation error for the location variable

### DIFF
--- a/skyview978_main.cc
+++ b/skyview978_main.cc
@@ -103,7 +103,7 @@ static int realmain(int argc, char **argv) {
         }
     });
 
-    boost::optional<std::pair<double, double>> location = boost::none;
+    boost::optional<std::pair<double, double>> location = boost::make_optional(false, std::make_pair(0.0, 0.0));
     if (opts.count("lat") && opts.count("lon")) {
         location.emplace(opts["lat"].as<double>(), opts["lon"].as<double>());
     }


### PR DESCRIPTION
With gcc 8 there are some compilation errors with the boost::optional type.
(see for example https://stackoverflow.com/questions/21755206/how-to-get-around-gcc-void-b-4-may-be-used-uninitialized-in-this-funct)

This seemed to be the best work-around i could find.
Probably no one else is compiling this software on gcc8, so feel free to disregard this pull request :)

Actual compilation error i had with gcc version 8.3.0 (Debian 8.3.0-5):
```
g++ -std=c++11 -Wall -Wno-psabi -Werror -O2 -g -Ilibs -DVERSION=\"3728f6e\"  -c -o skyview978_main.o skyview978_main.cc
skyview978_main.cc: In function ‘int realmain(int, char**)’:
skyview978_main.cc:106:48: error: ‘*((void*)(& location)+8).std::pair<double, double>::second’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     boost::optional<std::pair<double, double>> location = boost::none;
                                                ^~~~~~~~
skyview978_main.cc:106:48: error: ‘*((void*)(& location)+8).std::pair<double, double>::first’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
cc1plus: all warnings being treated as errors
make: *** [<builtin>: skyview978_main.o] Error 1

```