### PR TITLE
Fix getting LAT/LON from piaware .env file

### DIFF
--- a/debian/start-skyview978
+++ b/debian/start-skyview978
@@ -21,9 +21,9 @@ then
     exit 64
 fi
 
-if [ -n "$LAT" -a -n "$LON" ]
+if [ -n "$PIAWARE_LAT" -a -n "$PIAWARE_LON" ]
 then
-    POSITION="--lat $LAT --lon $LON"
+    POSITION="--lat $PIAWARE_LAT --lon $PIAWARE_LON"
 fi
 
 exec /usr/bin/skyview978 \


### PR DESCRIPTION
Same problem as dump1090-fa, didn't think of fixing it for 978 as well when abcd567 mentioned the problem.