### PR TITLE
Skyview: Non-ambiguous date and time formats

### DIFF
--- a/skyview/script.js
+++ b/skyview/script.js
@@ -1193,7 +1193,8 @@ function refreshHighlighted() {
 }
 
 function refreshClock() {
-	$('#clock_div').text(new Date().toLocaleString());
+        var dopt = { year: 'numeric', month: 'short', day: 'numeric', hour: 'numeric', minute: 'numeric', second: 'numeric', hour12: false };
+        $('#clock_div').text(new Date().toLocaleString(undefined,dopt));
 	var c = setTimeout(refreshClock, 500);
 }
 


### PR DESCRIPTION
This will eliminate ambiguity, while still keeping US folk happy, because currently looking at date like 05/04/2019 no one can tell if it is April on May without additional context (like what browser language is set, what os locale is set, what the software respects - OS locale or browser locale, etc.). And even then don’t assume anything. Good example is my setup, I am US resident and you would expect MM/DD/YYYY on my computers but you will be wrong, as I have my OS locales set to en_GB because that means more internationally compatible date and time formats everywhere. Also I’m from Russia and “middle endian” date breaks my brain everytime.

Date will be:

May 4, 2019, 14:07:59 - for US locale
4 May 2019, 14:07:59 - for GB locale

I think it's a good compromise. Other option is to solely use ISO 8601 without taking any locales into account.