### PR TITLE
Fixed stdin samples not being processed.

### DIFF
--- a/sample_source.cc
+++ b/sample_source.cc
@@ -102,6 +102,8 @@ void StdinSampleSource::ScheduleRead() {
         return;
     }
 
+    block_.resize(block_.capacity());
+
     auto self = shared_from_this();
     stream_.async_read_some(boost::asio::buffer(block_.data() + used_, block_.size() - used_), [this, self](const boost::system::error_code &ec, std::size_t bytes_transferred) {
         if (ec) {


### PR DESCRIPTION
Discovered when trying to use a combination of rtl_tcp and netcat. You can also reproduce with "cat samplefile.bin | ./dump978 --stdin ..."

block_.size() always returns 0 because the block is never resized after it is allocated. Modified to resize the buffer each time the callback happens like in the FileSampleSource::ReadBlock.

As a side note, is there a place to discuss the code specifically? I use dump978 and dump1090 outside of the piaware environment to feed states to another system. I'm curious about how you guys use the TSV and/or json on the backend. Do you expect the TSV to stick around for a while etc. Just cant seem to find the right forum.