### PR TITLE
Fix: Remove obsolete skyview978 conffiles

### DIFF
--- a/debian/skyaware978.postinst
+++ b/debian/skyaware978.postinst
@@ -29,7 +29,7 @@ case "$1" in
 
 	if dpkg --compare-versions "$2" lt "3.7.2~"
 	then
-		lighty-disable-mod skyview978 || true
+		rm /etc/lighttpd/conf-enabled/89-skyview978.conf || true
 	fi
 
         # set up lighttpd

--- a/debian/skyaware978.postinst
+++ b/debian/skyaware978.postinst
@@ -30,6 +30,7 @@ case "$1" in
 	if dpkg --compare-versions "$2" lt "3.7.2~"
 	then
 		rm /etc/lighttpd/conf-enabled/89-skyview978.conf || true
+		rm /etc/lighttpd/conf-enabled/88-skyview978-statcache.conf || true
 	fi
 
         # set up lighttpd


### PR DESCRIPTION
Due to the apt process, the actual config file in conf-available is at
least sometimes removed before lighty-disable-mod is called.
This leads to lighty-disable-mod not working and lighttpd failing to
start.
To fix that problem, just delete the symlink in conf-enabled.

See also this forum thread with a user reporting that problem:
 https://discussions.flightaware.com/t/skyview-after-update-3-7-2-refused-to-connect/55011