### PR TITLE
Do not suggest Debian package dh-systemd in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ for use by the SkyAware web map.
 $ sudo apt-get install \
   build-essential \
   debhelper \
-  dh-systemd \
   libboost-system-dev \
   libboost-program-options-dev \
   libboost-regex-dev \


### PR DESCRIPTION
The README file suggest that Debian package `dh-systemd` is required to build the .deb package. However, that package was marked as "transitional" several years ago, and does not exist in bullseye.