### PR TITLE
Clang build fixes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,7 @@ jobs:
           - gcc-10
           - gcc-12
           - gcc-14
+          - clang-20
         include:
           - cc: gcc-10
             cxx: g++-10
@@ -22,6 +23,8 @@ jobs:
             cxx: g++-12
           - cc: gcc-14
             cxx: g++-14
+          - cc: clang-20
+            cxx: clang-20
     runs-on: ${{ matrix.image }}
     env:
       CC: ${{ matrix.cc }}

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test: fec_tests
 	./fec_tests
 
 fec_tests: fec_tests.o libs/fec/init_rs_char.o libs/fec/decode_rs_char.o libs/fec/encode_rs_char.o
-	$(CXX) $(CXXFLAGS) $(LDFLAGS) $^ -o $@
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) $^ -o $@ -lstdc++
 
 format:
 	clang-format -style=file -i *.cc *.h

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ CFLAGS += -Wall -Werror -O2 -g -Ilibs
 CXX ?= g++
 CXXFLAGS += -std=c++11 -Wall -Wno-psabi -Werror -O2 -g -Ilibs
 
-LIBS=-lboost_system -lboost_program_options -lboost_regex -lboost_filesystem -lpthread
+LIBS=-lboost_system -lboost_program_options -lboost_regex -lboost_filesystem -lpthread -lstdc++ -lm
 LIBS_SDR=-lSoapySDR
 
 all: dump978-fa skyaware978

--- a/common.h
+++ b/common.h
@@ -16,7 +16,8 @@
 #include <cstdint>
 #include <vector>
 
-namespace flightaware::uat {
+namespace flightaware {
+  namespace uat {
     typedef std::vector<std::uint8_t> Bytes;
     typedef std::vector<std::uint16_t> PhaseBuffer;
 
@@ -28,6 +29,7 @@ namespace flightaware::uat {
     const auto unix_epoch = std::chrono::system_clock::from_time_t(0);
 
     inline static std::uint64_t now_millis() { return std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - unix_epoch).count(); }
-}; // namespace flightaware::uat
+  }; // namespace flightaware::uat
+};   // namespace flightaware
 
 #endif

--- a/convert.cc
+++ b/convert.cc
@@ -172,15 +172,6 @@ void CS8Converter::ConvertMagSq(Bytes::const_iterator begin, Bytes::const_iterat
     }
 }
 
-static inline std::int16_t PhaseDifference(std::uint16_t from, std::uint16_t to) {
-    int32_t difference = to - from; // lies in the range -65535 .. +65535
-    if (difference >= 32768)        //   +32768..+65535
-        return difference - 65536;  //   -> -32768..-1: always in range
-    else if (difference < -32768)   //   -65535..-32769
-        return difference + 65536;  //   -> +1..32767: always in range
-    else
-        return difference;
-}
 CS16HConverter::CS16HConverter() : SampleConverter(SampleFormat::CS16H) {
     // atan lookup, positive values only, 8-bit fixed point covering 0.0 .. 256.0
     for (std::size_t i = 0; i < lookup_atan_.size(); ++i) {

--- a/convert.h
+++ b/convert.h
@@ -12,7 +12,8 @@
 
 #include "common.h"
 
-namespace flightaware::uat {
+namespace flightaware {
+  namespace uat {
     // Describes a sample data layout:
     //   CU8   - interleaved I/Q data, 8 bit unsigned integers
     //   CS8_  - interleaved I/Q data, 8 bit signed integers
@@ -119,6 +120,7 @@ namespace flightaware::uat {
         void ConvertPhase(Bytes::const_iterator begin, Bytes::const_iterator end, PhaseBuffer::iterator out) override;
         void ConvertMagSq(Bytes::const_iterator begin, Bytes::const_iterator end, std::vector<double>::iterator out) override;
     };
-}; // namespace flightaware::uat
+  }; // namespace flightaware::uat
+};   // namespace flightaware
 
 #endif

--- a/demodulator.h
+++ b/demodulator.h
@@ -16,7 +16,8 @@
 #include "message_source.h"
 #include "uat_message.h"
 
-namespace flightaware::uat {
+namespace flightaware {
+  namespace uat {
     class Demodulator {
       public:
         // Return value of Demodulate
@@ -69,7 +70,7 @@ namespace flightaware::uat {
 
         PhaseBuffer phase_;
     };
-
-}; // namespace flightaware::uat
+  }; // namespace flightaware::uat
+};   // namespace flightaware
 
 #endif

--- a/dump978_main.cc
+++ b/dump978_main.cc
@@ -51,7 +51,8 @@ void validate(boost::any &v, const std::vector<std::string> &values, listen_opti
 }
 
 // Specializations of validate for --format
-namespace flightaware::uat {
+namespace flightaware {
+  namespace uat {
     void validate(boost::any &v, const std::vector<std::string> &values, SampleFormat *target_type, int) {
         po::validators::check_first_occurrence(v);
         const std::string &s = po::validators::get_single_string(values);
@@ -71,7 +72,8 @@ namespace flightaware::uat {
 
         v = boost::any(entry->second);
     }
-} // namespace flightaware::uat
+  } // namespace flightaware::uat
+} // namespace flightaware
 
 #define EXIT_NO_RESTART (64)
 

--- a/exception.h
+++ b/exception.h
@@ -9,12 +9,14 @@
 
 #include <stdexcept>
 
-namespace flightaware::uat {
+namespace flightaware {
+  namespace uat {
     class config_error : public std::runtime_error {
       public:
         explicit config_error(const std::string &what_arg) : runtime_error(what_arg) {}
         explicit config_error(const char *what_arg) : runtime_error(what_arg) {}
     };
-}; // namespace flightaware::uat
+  }; // namespace flightaware::uat
+};   // namespace flightaware
 
 #endif

--- a/faup978_reporter.h
+++ b/faup978_reporter.h
@@ -17,7 +17,8 @@
 #include "track.h"
 #include "uat_message.h"
 
-namespace flightaware::faup978 {
+namespace flightaware {
+  namespace faup978 {
     struct ReportState {
         std::uint64_t slow_report_time = 0;
         std::uint64_t report_time = 0;
@@ -57,6 +58,7 @@ namespace flightaware::faup978 {
         std::map<flightaware::uat::Tracker::AddressKey, ReportState> reported_;
         bool fecfix_ = false;
     };
-} // namespace flightaware::faup978
+  }; // namespace flightaware::faup978
+};   // namespace flightaware
 
 #endif

--- a/fec.h
+++ b/fec.h
@@ -11,7 +11,8 @@
 
 #include "common.h"
 
-namespace flightaware::uat {
+namespace flightaware {
+  namespace uat {
     // Deinterleaving and error-correction of UAT messages.
     // This delegates to the "fec" library (in fec/) for the actual Reed-Solomon
     // error-correction work.
@@ -48,6 +49,7 @@ namespace flightaware::uat {
         void *rs_downlink_short_;
         void *rs_downlink_long_;
     };
-}; // namespace flightaware::uat
+  }; // namespace flightaware::uat
+};   // namespace flightaware
 
 #endif

--- a/libs/json.hpp
+++ b/libs/json.hpp
@@ -20355,7 +20355,7 @@ if no parse error occurred.
 
 @since version 1.0.0
 */
-inline nlohmann::json operator "" _json(const char* s, std::size_t n)
+inline nlohmann::json operator ""_json(const char* s, std::size_t n)
 {
     return nlohmann::json::parse(s, s + n);
 }
@@ -20373,7 +20373,7 @@ object if no parse error occurred.
 
 @since version 2.0.0
 */
-inline nlohmann::json::json_pointer operator "" _json_pointer(const char* s, std::size_t n)
+inline nlohmann::json::json_pointer operator ""_json_pointer(const char* s, std::size_t n)
 {
     return nlohmann::json::json_pointer(std::string(s, n));
 }

--- a/message_dispatch.h
+++ b/message_dispatch.h
@@ -14,7 +14,8 @@
 
 #include "uat_message.h"
 
-namespace flightaware::uat {
+namespace flightaware {
+  namespace uat {
     class MessageDispatch {
       public:
         typedef unsigned Handle;
@@ -44,6 +45,7 @@ namespace flightaware::uat {
 
         std::map<Handle, Client> clients_;
     };
-}; // namespace flightaware::uat
+  }; // namespace flightaware::uat
+};   // namespace flightaware
 
 #endif

--- a/message_source.h
+++ b/message_source.h
@@ -11,7 +11,8 @@
 
 #include "uat_message.h"
 
-namespace flightaware::uat {
+namespace flightaware {
+  namespace uat {
     class MessageSource {
       public:
         typedef std::shared_ptr<MessageSource> Pointer;
@@ -43,6 +44,7 @@ namespace flightaware::uat {
         Consumer consumer_;
         ErrorHandler error_handler_;
     };
-}; // namespace flightaware::uat
+  }; // namespace flightaware::uat
+};   // namespace flightaware
 
 #endif

--- a/sample_source.h
+++ b/sample_source.h
@@ -108,7 +108,7 @@ namespace flightaware {
         SampleFormat Format() override { return format_; }
 
       private:
-        StdinSampleSource(boost::asio::io_service &service, const boost::program_options::variables_map &options, std::size_t samples_per_second, std::size_t samples_per_block) : service_(service), samples_per_second_(samples_per_second), stream_(service), used_(0) {
+        StdinSampleSource(boost::asio::io_service &service, const boost::program_options::variables_map &options, std::size_t samples_per_second, std::size_t samples_per_block) : samples_per_second_(samples_per_second), stream_(service), used_(0) {
             if (!options.count("format")) {
                 throw std::runtime_error("--format must be specified when using a file input");
             }
@@ -120,7 +120,6 @@ namespace flightaware {
 
         void ScheduleRead();
 
-        boost::asio::io_service &service_;
         SampleFormat format_;
         unsigned alignment_;
         std::size_t samples_per_second_;

--- a/sample_source.h
+++ b/sample_source.h
@@ -21,7 +21,8 @@
 #include "common.h"
 #include "convert.h"
 
-namespace flightaware::uat {
+namespace flightaware {
+  namespace uat {
     class SampleSource : public std::enable_shared_from_this<SampleSource> {
       public:
         typedef std::shared_ptr<SampleSource> Pointer;
@@ -127,6 +128,7 @@ namespace flightaware::uat {
         Bytes block_;
         std::size_t used_;
     };
-}; // namespace flightaware::uat
+  }; // namespace flightaware::uat
+};   // namespace flightaware
 
 #endif

--- a/skyaware_writer.h
+++ b/skyaware_writer.h
@@ -30,11 +30,10 @@ namespace flightaware {
         void Stop();
 
       private:
-        SkyAwareWriter(boost::asio::io_service &service, flightaware::uat::Tracker::Pointer tracker, const boost::filesystem::path &dir, std::chrono::milliseconds interval, unsigned history_count, std::chrono::milliseconds history_interval, boost::optional<std::pair<double, double>> location) : service_(service), strand_(service), timer_(service), tracker_(tracker), dir_(dir), interval_(interval), history_count_(history_count), history_interval_(history_interval), location_(location) {}
+        SkyAwareWriter(boost::asio::io_service &service, flightaware::uat::Tracker::Pointer tracker, const boost::filesystem::path &dir, std::chrono::milliseconds interval, unsigned history_count, std::chrono::milliseconds history_interval, boost::optional<std::pair<double, double>> location) : strand_(service), timer_(service), tracker_(tracker), dir_(dir), interval_(interval), history_count_(history_count), history_interval_(history_interval), location_(location) {}
 
         void PeriodicWrite();
 
-        boost::asio::io_service &service_;
         boost::asio::io_service::strand strand_;
         boost::asio::steady_timer timer_;
         flightaware::uat::Tracker::Pointer tracker_;

--- a/skyaware_writer.h
+++ b/skyaware_writer.h
@@ -18,7 +18,8 @@
 #include "track.h"
 #include "uat_message.h"
 
-namespace flightaware::skyaware {
+namespace flightaware {
+  namespace skyaware {
     class SkyAwareWriter : public std::enable_shared_from_this<SkyAwareWriter> {
       public:
         typedef std::shared_ptr<SkyAwareWriter> Pointer;
@@ -45,6 +46,7 @@ namespace flightaware::skyaware {
         unsigned next_history_index_ = 0;
         std::uint64_t next_history_time_ = 0;
     };
-} // namespace flightaware::skyaware
+  }; // namespace flightaware::skyaware
+};   // namespace flightaware
 
 #endif

--- a/soapy_source.h
+++ b/soapy_source.h
@@ -15,7 +15,8 @@
 
 #include "sample_source.h"
 
-namespace flightaware::uat {
+namespace flightaware {
+  namespace uat {
     class SoapySampleSource : public SampleSource {
       public:
         static SampleSource::Pointer Create(boost::asio::io_service &service, const std::string &device_name, const boost::program_options::variables_map &options) { return Pointer(new SoapySampleSource(service, device_name, options)); }
@@ -45,6 +46,7 @@ namespace flightaware::uat {
 
         static std::atomic_bool log_handler_registered_;
     };
-}; // namespace flightaware::uat
+  }; // namespace flightaware::uat
+};   // namespace flightaware
 
 #endif

--- a/socket_input.cc
+++ b/socket_input.cc
@@ -9,7 +9,7 @@ using boost::asio::ip::tcp;
 
 #include <iostream>
 
-RawInput::RawInput(boost::asio::io_service &service, const std::string &host, const std::string &port_or_service, std::chrono::milliseconds reconnect_interval) : service_(service), host_(host), port_or_service_(port_or_service), reconnect_interval_(reconnect_interval), resolver_(service), socket_(service), reconnect_timer_(service), used_(0) { readbuf_.resize(8192); }
+RawInput::RawInput(boost::asio::io_service &service, const std::string &host, const std::string &port_or_service, std::chrono::milliseconds reconnect_interval) : host_(host), port_or_service_(port_or_service), reconnect_interval_(reconnect_interval), resolver_(service), socket_(service), reconnect_timer_(service), used_(0) { readbuf_.resize(8192); }
 
 void RawInput::Start() {
     auto self(shared_from_this());

--- a/socket_input.h
+++ b/socket_input.h
@@ -40,7 +40,6 @@ namespace flightaware {
         boost::optional<RawMessage> ParseMetadataLine(const std::string &line);
         void HandleError(const boost::system::error_code &ec);
 
-        boost::asio::io_service &service_;
         std::string host_;
         std::string port_or_service_;
         std::chrono::milliseconds reconnect_interval_;

--- a/socket_input.h
+++ b/socket_input.h
@@ -16,7 +16,8 @@
 
 #include "message_source.h"
 
-namespace flightaware::uat {
+namespace flightaware {
+  namespace uat {
     class RawInput : public MessageSource, public std::enable_shared_from_this<RawInput> {
       public:
         typedef std::shared_ptr<RawInput> Pointer;
@@ -54,6 +55,7 @@ namespace flightaware::uat {
         std::vector<char> readbuf_;
         std::size_t used_;
     };
-}; // namespace flightaware::uat
+  }; // namespace flightaware::uat
+};   // namespace flightaware
 
 #endif

--- a/socket_output.cc
+++ b/socket_output.cc
@@ -16,7 +16,7 @@ using boost::asio::ip::tcp;
 
 using namespace flightaware::uat;
 
-SocketOutput::SocketOutput(asio::io_service &service, tcp::socket &&socket) : service_(service), strand_(service), socket_(std::move(socket)), peer_(socket_.remote_endpoint()), flush_pending_(false) {}
+SocketOutput::SocketOutput(asio::io_service &service, tcp::socket &&socket) : strand_(service), socket_(std::move(socket)), peer_(socket_.remote_endpoint()), flush_pending_(false) {}
 
 void SocketOutput::Start() { ReadAndDiscard(); }
 

--- a/socket_output.h
+++ b/socket_output.h
@@ -44,7 +44,6 @@ namespace flightaware {
         void Flush();
         void ReadAndDiscard();
 
-        boost::asio::io_service &service_;
         boost::asio::io_service::strand strand_;
         boost::asio::ip::tcp::socket socket_;
         boost::asio::ip::tcp::endpoint peer_;

--- a/socket_output.h
+++ b/socket_output.h
@@ -17,7 +17,8 @@
 #include "message_dispatch.h"
 #include "uat_message.h"
 
-namespace flightaware::uat {
+namespace flightaware {
+  namespace uat {
     class SocketOutput : public std::enable_shared_from_this<SocketOutput> {
       public:
         typedef std::shared_ptr<SocketOutput> Pointer;
@@ -106,6 +107,7 @@ namespace flightaware::uat {
         MessageDispatch &dispatch_;
         ConnectionFactory factory_;
     };
-}; // namespace flightaware::uat
+  }; // namespace flightaware::uat
+};   // namespace flightaware
 
 #endif

--- a/socket_output.h
+++ b/socket_output.h
@@ -30,6 +30,8 @@ namespace flightaware::uat {
 
         bool IsOpen() const { return socket_.is_open(); }
 
+        virtual ~SocketOutput() {};
+
       protected:
         SocketOutput(boost::asio::io_service &service_, boost::asio::ip::tcp::socket &&socket_);
         std::ostringstream &Buf() { return outbuf_; }

--- a/stratux_serial.cc
+++ b/stratux_serial.cc
@@ -34,7 +34,7 @@ enum class StratuxSerial::ParserState {
     MESSAGE   // reading rssi / timestamp / payload
 };
 
-StratuxSerial::StratuxSerial(boost::asio::io_service &io_service, const std::string &path) : io_service_(io_service), path_(path), port_(io_service), read_timer_(io_service), parser_state_(ParserState::PREAMBLE), preamble_index_(0) {}
+StratuxSerial::StratuxSerial(boost::asio::io_service &io_service, const std::string &path) : path_(path), port_(io_service), read_timer_(io_service), parser_state_(ParserState::PREAMBLE), preamble_index_(0) {}
 
 void StratuxSerial::Start() {
     try {

--- a/stratux_serial.h
+++ b/stratux_serial.h
@@ -49,7 +49,6 @@ namespace flightaware {
         // how long to wait between scheduling reads (to reduce the spinning on short messages)
         const std::chrono::milliseconds read_interval = std::chrono::milliseconds(50);
 
-        boost::asio::io_service &io_service_;
         std::string path_;
         boost::asio::serial_port port_;
         boost::asio::steady_timer read_timer_;

--- a/stratux_serial.h
+++ b/stratux_serial.h
@@ -22,7 +22,8 @@
 #include "fec.h"
 #include "message_source.h"
 
-namespace flightaware::uat {
+namespace flightaware {
+  namespace uat {
     class StratuxSerial : public MessageSource, public std::enable_shared_from_this<StratuxSerial> {
       public:
         typedef std::shared_ptr<StratuxSerial> Pointer;
@@ -62,6 +63,7 @@ namespace flightaware::uat {
         Bytes message_;
         std::uint64_t message_start_timestamp_;
     };
-}; // namespace flightaware::uat
+  }; // namespace flightaware::uat
+};   // namespace flightaware
 
 #endif

--- a/track.h
+++ b/track.h
@@ -18,7 +18,8 @@
 
 #include "uat_message.h"
 
-namespace flightaware::uat {
+namespace flightaware {
+  namespace uat {
     class AgedFieldBase {
       public:
         operator bool() const { return Valid(); }
@@ -169,6 +170,7 @@ namespace flightaware::uat {
         MapType aircraft_;
         std::uint32_t total_messages_ = 0;
     };
-}; // namespace flightaware::uat
+  }; // namespace flightaware::uat
+};   // namespace flightaware
 
 #endif

--- a/track.h
+++ b/track.h
@@ -159,11 +159,10 @@ namespace flightaware {
         void PurgeOld();
 
       private:
-        Tracker(boost::asio::io_service &service, std::chrono::milliseconds timeout) : service_(service), strand_(service), timer_(service), timeout_(timeout) {}
+        Tracker(boost::asio::io_service &service, std::chrono::milliseconds timeout) : strand_(service), timer_(service), timeout_(timeout) {}
 
         void HandleMessage(const AdsbMessage &message);
 
-        boost::asio::io_service &service_;
         boost::asio::io_service::strand strand_;
         boost::asio::steady_timer timer_;
         std::chrono::milliseconds timeout_;

--- a/uat_message.cc
+++ b/uat_message.cc
@@ -432,7 +432,8 @@ void AdsbMessage::DecodeAUXSV(const RawMessage &raw) {
 // converting decoded messages to json
 //
 
-namespace flightaware::uat {
+namespace flightaware {
+  namespace uat {
     // clang-format off
 
     NLOHMANN_JSON_SERIALIZE_ENUM(AddressQualifier, {
@@ -485,7 +486,8 @@ namespace flightaware::uat {
     });
 
     // clang-format on
-}; // namespace flightaware::uat
+  }; // namespace flightaware::uat
+}; // namespace flightaware
 
 nlohmann::json AdsbMessage::ToJson() const {
     nlohmann::json o;

--- a/uat_message.h
+++ b/uat_message.h
@@ -17,7 +17,8 @@
 #include "common.h"
 #include "uat_protocol.h"
 
-namespace flightaware::uat {
+namespace flightaware {
+  namespace uat {
     class RawMessage {
       public:
         using MetadataMap = std::map<std::string, std::string>;
@@ -296,6 +297,7 @@ namespace flightaware::uat {
         void DecodeMS(const RawMessage &raw);
         void DecodeAUXSV(const RawMessage &raw);
     };
-} // namespace flightaware::uat
+  }; // namespace flightaware::uat
+};   // namespace flightaware
 
 #endif

--- a/uat_protocol.h
+++ b/uat_protocol.h
@@ -9,7 +9,8 @@
 
 #include <cstdint>
 
-namespace flightaware::uat {
+namespace flightaware {
+  namespace uat {
     enum class MessageType { DOWNLINK_SHORT, DOWNLINK_LONG, UPLINK, METADATA, INVALID };
 
     const unsigned SYNC_BITS = 36;
@@ -49,7 +50,8 @@ namespace flightaware::uat {
         const int DOWNLINK_SHORT_PAD = 255 - DOWNLINK_SHORT_BYTES;
         const int DOWNLINK_LONG_PAD = 255 - DOWNLINK_LONG_BYTES;
         const int UPLINK_BLOCK_PAD = 255 - UPLINK_BLOCK_BYTES;
-    }; // namespace fec
-};     // namespace flightaware::uat
+    }; // namespace flightaware::uat::fec
+  }; // namespace flightaware::uat
+};   // namespace flightaware
 
 #endif


### PR DESCRIPTION
Various build fixes for building under clang.

Lots of warning-cleanup fixes, mostly:
* remove many unused private fields (all are references, so there's no RAII issue from removing them)
* expand out nested namespace definitions as the multiple-level declaration form is C++17, and we build with C++11

and a couple of real fixes:
* a missing virtual dtor
* missing libstdc++ / libm linking
